### PR TITLE
Exclude solutions directories within homework

### DIFF
--- a/git-sync.sh
+++ b/git-sync.sh
@@ -65,6 +65,7 @@ declare -a toExclude=("README-public.md" # Public repo should only have the READ
                       ".github" # Exclude workflows
                       "examples" # Exclude internal examples
                       ".gitignore" # Ignore gitignore for simplicity
+                      ":(glob)homework/**/solutions/**" # Ignore everything inside solutions directories anywhere within homework
                       )
 
 # git rm all excluded pathspecs


### PR DESCRIPTION
Homework 1 has a solutions doc that should be included on git but not synced. This is a general way to support excluding everything inside any directory named "solutions" within the homework directory.

Testing
```
➜  git-sync git:(exclude-solutions) ✗ git status
On branch exclude-solutions
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
	modified:   git-sync.sh
	new file:   solutions/file1.txt
	new file:   tmp/file1
	new file:   tmp/solutions/file2
	new file:   tmp/solutions/sub/file3

➜  git-sync git:(exclude-solutions) ✗ git rm -f ":(glob)tmp/**/solutions/**"
rm 'tmp/solutions/file2'
rm 'tmp/solutions/sub/file3'
➜  git-sync git:(exclude-solutions) ✗ ls tmp
file1
```